### PR TITLE
Contexts can be inspected to return registered items and their deps

### DIFF
--- a/stirrups/app.py
+++ b/stirrups/app.py
@@ -27,7 +27,7 @@ class App:
     ):
         self._mount = mount
         self._mounted = False
-        self._providers = Registry()
+        self._providers = Registry[Provider]()
         self._includes = []
 
     def register(

--- a/stirrups/context.py
+++ b/stirrups/context.py
@@ -1,23 +1,91 @@
-from typing import Any, Callable, Dict, List, Optional, Type, TypeVar, Union
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Type,
+    TypedDict,
+    TypeVar,
+    Union,
+)
 
+from .exceptions import ContextNotMountedError
 from .injection import (
     Factory,
     Injectable,
+    InjectableMeta,
     Injector,
     Instance,
     ItemType,
     Provider,
+    generate_iface_key,
     injectable_factory,
 )
 
 
 ContextType = TypeVar('ContextType', bound='Context')
 
+InspectContextDictItemDep = TypedDict(
+    'InspectContextDictItemDep',
+    key=str,
+    param=str,
+)
+
+InspectContextDictItem = TypedDict(
+    'InspectContextDictItem',
+    key=str,
+    item=Union[str, List[str]],
+    deps=List[InspectContextDictItemDep]
+)
+
+
+class InspectContextResult:
+
+    def __init__(self, injectables: Dict[str, InjectableMeta]):
+        self.injectables = injectables
+
+    def __str__(self) -> str:
+        return str(self.injectables)
+
+    def to_dict(self) -> Dict[str, InspectContextDictItem]:
+        dic = {}
+        for key, injectable_meta in self.injectables.items():
+            item = injectable_meta['item']
+            if isinstance(item, list):
+                dic[key] = [
+                    self._item_to_dict(key, i)
+                    for i in item
+                ]
+                item = [str(i) for i in item]
+            else:
+                dic[key] = self._item_to_dict(key, item)
+        return dic
+
+    def _item_to_dict(
+        self,
+        key: str,
+        item: Injectable
+    ) -> InspectContextDictItem:
+        return {
+            'key': key,
+            'item': str(item),
+            'deps': [
+                {
+                    'param': param,
+                    'key': generate_iface_key(iface)
+                }
+                for param, iface in item.dependencies
+                if iface is not None
+            ]
+        }
+
 
 class Context:
     injector: Injector
 
     def __init__(self, *args: Any, **kwargs: Any):
+        self._mounted = False
         self.local_provider = Provider()
         self.local_provider.register(
             Instance(self),
@@ -30,6 +98,7 @@ class Context:
     def mount(self, *, providers: Optional[List[Provider]] = None):
         providers = providers or []
         self.injector = Injector([self.local_provider, *providers], self)
+        self._mounted = True
 
     def register(
         self,
@@ -102,6 +171,9 @@ class Context:
         args: Optional[List[Any]] = None,
         kwargs: Optional[Dict[str, Any]] = None
     ) -> ItemType:
+        if not self._mounted:
+            raise ContextNotMountedError()
+
         args = args or []
         kwargs = kwargs or {}
         return self.injector.resolve(
@@ -118,6 +190,9 @@ class Context:
         args: Optional[List[Any]] = None,
         kwargs: Optional[Dict[str, Any]] = None
     ) -> ItemType:
+        if not self._mounted:
+            raise ContextNotMountedError()
+
         args = args or []
         kwargs = kwargs or {}
         return self.injector.get(
@@ -135,6 +210,9 @@ class Context:
         args: Optional[List[Any]] = None,
         kwargs: Optional[Dict[str, Any]] = None
     ) -> List[ItemType]:
+        if not self._mounted:
+            raise ContextNotMountedError()
+
         args = args or []
         kwargs = kwargs or {}
         return self.injector.get_list(
@@ -143,3 +221,12 @@ class Context:
             args=[*args],
             kwargs={**kwargs}
         )
+
+    def inspect(self) -> InspectContextResult:
+        providers = self.injector._providers
+        unique_injectables = {}
+        for provider in reversed(providers):
+            injectables = provider.describe_injectables()
+            for injectable_meta in injectables:
+                unique_injectables[injectable_meta['key']] = injectable_meta
+        return InspectContextResult(unique_injectables)

--- a/stirrups/exceptions.py
+++ b/stirrups/exceptions.py
@@ -35,6 +35,14 @@ class AppNotMountedError(StirrupsError):
         )
 
 
+class ContextNotMountedError(StirrupsError):
+
+    def __init__(self):
+        super().__init__(
+            'Context is not mounted. Call context.mount() before proceeding.'
+        )
+
+
 class InjectionError(StirrupsError):
 
     def __init__(self, iface: Any, *, name: Union[str, None]):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -204,7 +204,7 @@ class TestInjection:
         assert a.deps_a == deps_a
 
     def test_inject_factory_class_with_annotations(self, app: App):
-        app.factory(TestInjection._DepsA, iface=self._DepsA)
+        app.factory(TestInjection._DepsA)
         app.factory(TestInjection._ClassA)
         app.factory(TestInjection._ClassB)
         app.mount()


### PR DESCRIPTION
Context return their deps in a `InspectContextResult` which can, in turn, be transformed to a dict. This provides a way to see all registered items and their dependencies.

If a context has more than one provider, only unique entries are kept to reflect exactly what the `.get` method would return.