### PR TITLE
Compose context from scope providers

### DIFF
--- a/stirrups/context.py
+++ b/stirrups/context.py
@@ -45,9 +45,6 @@ class InspectContextResult:
     def __init__(self, injectables: Dict[str, InjectableMeta]):
         self.injectables = injectables
 
-    def __str__(self) -> str:
-        return str(self.injectables)
-
     def to_dict(self) -> Dict[str, InspectContextDictItem]:
         dic = {}
         for key, injectable_meta in self.injectables.items():
@@ -86,7 +83,7 @@ class Context:
 
     def __init__(self, *args: Any, **kwargs: Any):
         self._mounted = False
-        self.local_provider = Provider()
+        self.local_provider = Provider('local')
         self.local_provider.register(
             Instance(self),
             aslist=False,

--- a/stirrups/injection.py
+++ b/stirrups/injection.py
@@ -475,8 +475,9 @@ class Registry(Generic[ItemType]):
 
 class Provider(Generic[ItemType]):
 
-    def __init__(self):
-        self._injectables = Registry[Injectable]()
+    def __init__(self, name: str):
+        self.name = name
+        self.items = Registry[Injectable]()
 
     def get(
         self,
@@ -485,7 +486,7 @@ class Provider(Generic[ItemType]):
         name: Union[str, None]
     ) -> Injectable[ItemType]:
         key = name or generate_iface_key(iface)
-        return self._injectables.get(key)
+        return self.items.get(key)
 
     def get_list(
         self,
@@ -494,7 +495,7 @@ class Provider(Generic[ItemType]):
         name: Union[str, None]
     ) -> List[Injectable[ItemType]]:
         key = name or generate_iface_key(iface)
-        return self._injectables.get_list(key)
+        return self.items.get_list(key)
 
     def register(
         self,
@@ -507,7 +508,7 @@ class Provider(Generic[ItemType]):
     ):
         iface = iface or injectable.item
         key = name or generate_iface_key(iface)
-        return self._injectables.register(
+        return self.items.register(
             injectable,
             key,
             force=force,
@@ -516,7 +517,7 @@ class Provider(Generic[ItemType]):
 
     def describe_injectables(self) -> List[InjectableMeta]:
         results = []
-        for key, item in self._injectables.dict().items():
+        for key, item in self.items.dict().items():
             results.append({
                 'key': key,
                 'item': item,

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2,7 +2,8 @@ import pytest
 
 from dataclasses import dataclass
 
-from stirrups.app import App, Context
+from stirrups.app import App
+from stirrups.context import Context
 from stirrups.exceptions import (
     AppMountedError,
     AppNotMountedError,
@@ -82,17 +83,19 @@ class TestRegistration:
         a = context.get(self._IClass)
         assert isinstance(a, self._DataClassA)
 
-    def test_register_in_context(self, app: App):
-        def a_factory(context: Context) -> TestRegistration._ClassA:
+    def test_register_in_scope(self, app: App):
+        scope = 'test'
+
+        def a_factory() -> TestRegistration._ClassA:
             return self._ClassA()
 
         app.factory(
             a_factory,
             iface=self._IClass,
-            context=TestCreateContext._Context
+            scope=scope
         )
         app.mount()
-        _context = app.create_context(TestCreateContext._Context)
+        _context = app.create_context(Context, scopes=[scope])
         a = _context.get(self._IClass)
         assert isinstance(a, self._ClassA)
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,6 +1,7 @@
 import pytest
 
-from stirrups.app import App, Context
+from stirrups.app import App
+from stirrups.context import Context
 from stirrups.exceptions import DependencyInjectionError
 
 


### PR DESCRIPTION
Scopes are simple strings with their own providers and a context is composed of one or many of them.